### PR TITLE
Declare contents: write explicitly in the release workflow

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -8,6 +8,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      # Needed by the "Release" step below. `write` is the repository default,
+      # but stating it explicitly means adding another scope here later (e.g.
+      # `id-token: write` for trusted publishing) cannot silently drop
+      # `contents` to `none`.
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Why

a `permissions` block added for PyPI trusted publishing:

```yaml
permissions:
  contents: read      # <-- silently dropped from the `write` default
  id-token: write
```

Declaring a `permissions` block **at all** drops every unlisted scope, so `contents` fell
from the repository default of `write` to `read`, and `softprops/action-gh-release` began
returning 403.

This repo has the same latent trap: the `build` job has no `permissions` block, so it relies
entirely on the repository default staying `write`. It works today, but the next person who
adds a scope here reintroduces the exact same silent breakage.

## Change

Declare `contents: write` explicitly on the `build` job. No behavioural change today: this
is what the job already gets by default.

`contents: write` is all this job needs — the `Release` step is the only consumer of the
token. The changelog extraction is local `awk`, and the pkg.go.dev warm-up is an
unauthenticated `curl` to `proxy.golang.org`.

fastly-py and fastly-rust already declare `contents: write` this way.

## Verification

`Release` only runs on a `v[0-9]*` tag push, so this is unexercised until the next release.
It is a one-line permission grant matching the current effective default, so the risk is
that a *missing* scope surfaces at release time — hence the audit of the job's steps above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
